### PR TITLE
Runtime: Implement better JSValue -> JVM type conversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@
 # .idea/modules
 # *.iml
 # *.ipr
+.idea/
 
 # CMake
 cmake-build-*/

--- a/build.gradle
+++ b/build.gradle
@@ -24,11 +24,13 @@ dependencies {
     implementation 'org.ow2.asm:asm-tree:8.0.1'
     implementation 'org.ow2.asm:asm-commons:8.0.1'
     implementation 'com.github.mattco98:Koffee:3b4b48e9ff'
+
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.7.0"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.7.0"
     testImplementation 'com.charleskorn.kaml:kaml:0.25.0'
     testImplementation 'org.jetbrains.kotlin:kotlin-test-junit5'
     testImplementation 'org.jetbrains.kotlinx:kotlinx-serialization-runtime-jvm:1.0-M1-1.4.0-rc'
+    testImplementation "io.strikt:strikt-core:0.28.0"
 }
 
 test {

--- a/src/main/kotlin/me/mattco/reeva/runtime/Operations.kt
+++ b/src/main/kotlin/me/mattco/reeva/runtime/Operations.kt
@@ -274,7 +274,7 @@ object Operations {
     }
 
     @JvmStatic @ECMAImpl("6.1.6.1.20")
-    fun numericToString(value: JSValue): JSValue {
+    fun numericToString(value: JSValue): JSString {
         expect(value is JSNumber)
         if (value.isNaN)
             return "NaN".toValue()

--- a/src/main/kotlin/me/mattco/reeva/runtime/jvmcompat/JVMValueMapper.kt
+++ b/src/main/kotlin/me/mattco/reeva/runtime/jvmcompat/JVMValueMapper.kt
@@ -2,15 +2,264 @@ package me.mattco.reeva.runtime.jvmcompat
 
 import me.mattco.reeva.core.Realm
 import me.mattco.reeva.runtime.JSValue
+import me.mattco.reeva.runtime.Operations
 import me.mattco.reeva.runtime.arrays.JSArrayObject
 import me.mattco.reeva.runtime.builtins.JSMapObject
 import me.mattco.reeva.runtime.builtins.JSSetObject
-import me.mattco.reeva.runtime.primitives.JSNull
-import me.mattco.reeva.runtime.primitives.JSNumber
-import me.mattco.reeva.runtime.primitives.JSString
-import me.mattco.reeva.runtime.primitives.JSUndefined
+import me.mattco.reeva.runtime.objects.JSObject
+import me.mattco.reeva.runtime.primitives.*
+import me.mattco.reeva.utils.Errors
+import me.mattco.reeva.utils.JSArguments
+import me.mattco.reeva.utils.toValue
+import java.lang.reflect.Executable
+import java.lang.reflect.ParameterizedType
+import java.lang.reflect.Type
 
+/**
+ * Based on the [https://www-archive.mozilla.org/js/liveconnect/lc3_method_overloading.html]
+ * specification.
+ */
 object JVMValueMapper {
+    const val CONVERSION_FAILURE = -1
+
+    fun getConversionWeight(value: JSValue, type: Class<*>) = when (value) {
+        is JSUndefined -> 1
+        is JSBoolean -> {
+            when (type) {
+                Boolean::class.javaPrimitiveType -> 1
+                Boolean::class.javaObjectType -> 2
+                Any::class.java -> 3
+                String::class.java -> 4
+                else -> CONVERSION_FAILURE
+            }
+        }
+        is JSNumber -> {
+            when (type) {
+                Double::class.javaPrimitiveType -> 1
+                Double::class.javaObjectType -> 2
+                Float::class.javaPrimitiveType, Float::class.javaObjectType -> 3
+                Long::class.javaPrimitiveType, Long::class.javaObjectType -> 4
+                Int::class.javaPrimitiveType, Int::class.javaObjectType -> 5
+                Short::class.javaPrimitiveType, Short::class.javaObjectType -> 6
+                Byte::class.javaPrimitiveType, Byte::class.javaObjectType -> 7
+                Char::class.javaPrimitiveType, Char::class.javaObjectType ->
+                    if (value.isNaN) CONVERSION_FAILURE else 8
+                String::class.java -> 9
+                Any::class.java -> 10
+                else -> CONVERSION_FAILURE
+            }
+        }
+        is JSString -> {
+            when (type) {
+                String::class.java -> 1
+                Any::class.java -> 2
+                Char::class.javaPrimitiveType, Char::class.javaObjectType -> 3
+                Double::class.javaPrimitiveType, Double::class.javaObjectType -> 4
+                Float::class.javaPrimitiveType, Float::class.javaObjectType -> 5
+                Long::class.javaPrimitiveType, Long::class.javaObjectType -> 6
+                Int::class.javaPrimitiveType, Int::class.javaObjectType -> 7
+                Short::class.javaPrimitiveType, Short::class.javaObjectType -> 8
+                Byte::class.javaPrimitiveType, Byte::class.javaObjectType -> 9
+                else -> CONVERSION_FAILURE
+            }
+        }
+        is JSNull -> {
+            if (!type.isPrimitive)
+                1
+            else
+                CONVERSION_FAILURE
+        }
+        is JSClassInstanceObject -> {
+            val javaObject = value.obj
+            if (type.isInstance(javaObject))
+                1
+            else when (type) {
+                String::class.java -> 2
+                Double::class.javaPrimitiveType, Double::class.javaObjectType -> 3
+                Float::class.javaPrimitiveType, Float::class.javaObjectType -> 4
+                Long::class.javaPrimitiveType, Long::class.javaObjectType -> 5
+                Int::class.javaPrimitiveType, Int::class.javaObjectType -> 6
+                Short::class.javaPrimitiveType, Short::class.javaObjectType -> 7
+                Byte::class.javaPrimitiveType, Byte::class.javaObjectType -> 8
+                Char::class.javaPrimitiveType, Char::class.javaObjectType -> 9
+                else -> CONVERSION_FAILURE
+            }
+        }
+        is JSClassObject -> {
+            when (type) {
+                Class::class.java -> 1
+                Any::class.java -> 2
+                String::class.java -> 3
+                else -> CONVERSION_FAILURE
+            }
+        }
+        is JSArrayObject -> {
+            when {
+                type.isArray -> 1
+                List::class.java.isAssignableFrom(type) -> 2
+                else -> when (type) {
+                    Any::class.java -> 3
+                    String::class.java -> 4
+                    else -> CONVERSION_FAILURE
+                }
+            }
+        }
+        is JSObject -> {
+            when (type) {
+                Any::class.java -> 1
+                String::class.java -> 2
+                Double::class.javaPrimitiveType, Double::class.javaObjectType -> 3
+                Float::class.javaPrimitiveType, Float::class.javaObjectType -> 4
+                Long::class.javaPrimitiveType, Long::class.javaObjectType -> 5
+                Int::class.javaPrimitiveType, Int::class.javaObjectType -> 6
+                Short::class.javaPrimitiveType, Short::class.javaObjectType -> 7
+                Byte::class.javaPrimitiveType, Byte::class.javaObjectType -> 8
+                Char::class.javaPrimitiveType, Char::class.javaObjectType -> 9
+                else -> CONVERSION_FAILURE
+            }
+        }
+        else -> CONVERSION_FAILURE
+    }
+
+    @JvmOverloads
+    fun coerceValueToType(value: JSValue, type: Class<*>, genericInfo: Array<Type>? = null): Any? = when (value) {
+        is JSUndefined -> {
+            if (type == String::class.java)
+                "undefined"
+            else
+                null
+        }
+        is JSBoolean -> {
+            when (type) {
+                Boolean::class.javaPrimitiveType, Boolean::class.javaObjectType, Any::class.java -> value.value
+                String::class.java -> value.value.toString()
+                else -> Errors.JVMCompat.InconvertibleType(value, type).throwTypeError()
+            }
+        }
+        is JSNumber -> {
+            when (type) {
+                Double::class.javaPrimitiveType, Double::class.javaObjectType, Any::class.java -> value.number
+                Float::class.javaPrimitiveType, Float::class.javaObjectType -> value.number.toFloat() // TODO: Perhaps these conversion algos need more fine tuning
+                Long::class.javaPrimitiveType, Long::class.javaObjectType -> value.number.toLong()
+                Int::class.javaPrimitiveType, Int::class.javaObjectType -> value.number.toInt()
+                Short::class.javaPrimitiveType, Short::class.javaObjectType -> value.number.toInt().toShort()
+                Byte::class.javaPrimitiveType, Byte::class.javaObjectType -> value.number.toInt().toByte()
+                Char::class.javaPrimitiveType, Char::class.javaObjectType ->
+                    if (value.isNaN) Errors.JVMCompat.InconvertibleType(value, type).throwTypeError()
+                    else value.number.toInt().toChar()
+                String::class.java -> Operations.numericToString(value).string
+                else -> Errors.JVMCompat.InconvertibleType(value, type).throwTypeError()
+            }
+        }
+        is JSString -> {
+            when (type) {
+                String::class.java, Any::class.java -> value.string
+                Double::class.javaPrimitiveType, Double::class.javaObjectType, Float::class.javaPrimitiveType,
+                Float::class.javaObjectType, Long::class.javaPrimitiveType, Long::class.javaObjectType,
+                Int::class.javaPrimitiveType, Int::class.javaObjectType, Short::class.javaPrimitiveType,
+                Short::class.javaObjectType, Byte::class.javaPrimitiveType, Byte::class.javaObjectType ->
+                    coerceValueToType(Operations.toNumber(value), type)
+                Char::class.javaPrimitiveType, Char::class.javaObjectType ->
+                    if (value.string.length == 1) value.string[0] else coerceValueToType(Operations.toNumber(value), type)
+                else -> Errors.JVMCompat.InconvertibleType(value, type).throwTypeError()
+            }
+        }
+        is JSNull -> {
+            if (!type.isPrimitive)
+                null
+            else
+                Errors.JVMCompat.InconvertibleType(value, type).throwTypeError()
+        }
+        is JSClassInstanceObject -> {
+            val javaObject = value.obj
+            if (type.isInstance(javaObject))
+                javaObject
+            else when (type) {
+                String::class.java -> javaObject.toString()
+                Double::class.javaPrimitiveType, Double::class.javaObjectType, Float::class.javaPrimitiveType,
+                Float::class.javaObjectType, Long::class.javaPrimitiveType, Long::class.javaObjectType,
+                Int::class.javaPrimitiveType, Int::class.javaObjectType, Short::class.javaPrimitiveType,
+                Short::class.javaObjectType, Byte::class.javaPrimitiveType, Byte::class.javaObjectType ->
+                    coerceValueToType(javaObject.toString().toValue(), type)
+                else -> Errors.JVMCompat.InconvertibleType(value, type).throwTypeError()
+            }
+        }
+        is JSClassObject -> {
+            when (type) {
+                Class::class.java, Any::class.java -> value.clazz
+                String::class.java -> value.clazz.toString()
+                else -> Errors.JVMCompat.InconvertibleType(value, type).throwTypeError()
+            }
+        }
+        is JSArrayObject -> {
+            if (type == String::class.java) {
+                Operations.toString(value).string
+            } else if (List::class.java.isAssignableFrom(type)) {
+                val listInstance: MutableList<Any?> = if (type == List::class.java) mutableListOf() else type.newInstance() as MutableList<Any?>
+                val listType = genericInfo?.firstOrNull() as? Class<*> ?: Any::class.java
+
+                value.indexedProperties.indices().forEach { index ->
+                    listInstance.add(index, coerceValueToType(value.get(index), listType))
+                }
+
+                listInstance
+            } else if (type.isArray || type == Any::class.java) {
+                val arrayType = if (type.isArray) type.componentType else Any::class.java
+                val constructedArray = java.lang.reflect.Array.newInstance(arrayType, value.getLength(value).asInt)
+                value.indexedProperties.indices().forEach { index ->
+                    java.lang.reflect.Array.set(constructedArray, index, coerceValueToType(value.get(index), arrayType))
+                }
+                constructedArray
+            } else {
+                Errors.JVMCompat.InconvertibleType(value, type).throwTypeError()
+            }
+        }
+        is JSObject -> {
+            when (type) {
+                Any::class.java -> TODO("convert to map?")
+                String::class.java -> Operations.toString(value).string
+                Double::class.javaPrimitiveType, Double::class.javaObjectType, Float::class.javaPrimitiveType,
+                Float::class.javaObjectType, Long::class.javaPrimitiveType, Long::class.javaObjectType,
+                Int::class.javaPrimitiveType, Int::class.javaObjectType, Short::class.javaPrimitiveType,
+                Short::class.javaObjectType, Byte::class.javaPrimitiveType, Byte::class.javaObjectType ->
+                    coerceValueToType(
+                        Operations.toPrimitive(value, Operations.ToPrimitiveHint.AsNumber),
+                        type
+                    )
+                else -> Errors.JVMCompat.InconvertibleType(value, type).throwTypeError()
+            }
+        }
+        else -> Errors.JVMCompat.InconvertibleType(value, type).throwTypeError()
+    }
+
+    fun <T : Executable> findMatchingSignature(executables: List<T>, arguments: JSArguments): List<T> {
+        val weightedExecutables = executables.filter { it.parameterCount == arguments.size }.groupBy {
+            val weights = it.parameterTypes.withIndex().map { (i, type) -> getConversionWeight(arguments[i], type) }
+
+            if (weights.any { weight -> weight == CONVERSION_FAILURE })
+                CONVERSION_FAILURE
+            else
+                weights.sum()
+        }
+
+        val minWeight = weightedExecutables.keys.minOrNull() ?: return emptyList()
+        if (minWeight == CONVERSION_FAILURE)
+            return emptyList()
+        return weightedExecutables.getValue(minWeight)
+    }
+
+    fun coerceArgumentsToSignature(signature: Executable, arguments: JSArguments): List<Any?> {
+        val genericTypes = signature.genericParameterTypes
+
+        return arguments.mapIndexed { index, jsValue ->
+            val genericType = genericTypes[index]
+            if (genericType is ParameterizedType)
+                coerceValueToType(jsValue, genericType.rawType as Class<*>, genericInfo = genericType.actualTypeArguments)
+            else
+                coerceValueToType(jsValue, genericType as Class<*>)
+        }
+    }
+
     fun jvmToJS(realm: Realm, instance: Any?): JSValue {
         return when (instance) {
             null -> JSUndefined

--- a/src/main/kotlin/me/mattco/reeva/utils/Error.kt
+++ b/src/main/kotlin/me/mattco/reeva/utils/Error.kt
@@ -113,14 +113,28 @@ object Errors {
             "class $className with types: ${providedTypes.joinToString()}")
         class AmbiguousCtors(className: String, providedTypes: List<String>) : Error("more than one applicable constructor " +
             "found for class $className with types: ${providedTypes.joinToString()}")
+        class NoValidMethod(className: String, providedTypes: List<String>) : Error("no constructor found for " +
+            "class $className with types: ${providedTypes.joinToString()}")
+        class AmbiguousMethods(className: String, providedTypes: List<String>) : Error("more than one applicable constructor " +
+            "found for class $className with types: ${providedTypes.joinToString()}")
         class IncompatibleFieldGet(className: String, fieldName: String) : Error("invalid access of JVM field $fieldName " +
             "on object which is not an instance of the JVM class $className")
+        class IncompatibleStaticFieldGet(className: String, fieldName: String) : Error("invalid access of static JVM field $fieldName " +
+            "on object which is not the JVM class $className")
         class IncompatibleFieldSet(className: String, fieldName: String) : Error("invalid set of JVM field $fieldName " +
             "on object which is not an instance of the JVM class $className")
+        class IncompatibleStaticFieldSet(className: String, fieldName: String) : Error("invalid set of static JVM field $fieldName " +
+            "on object which is not the JVM class $className")
         class IncompatibleMethodCall(className: String, methodName: String) : Error("invalid call of JVM method $methodName " +
             "on object which is not an instance of the JVM class $className")
+        class IncompatibleStaticMethodCall(className: String, methodName: String) : Error("invalid call of static JVM method $methodName " +
+            "on object which is not the JVM class $className")
         class InvalidFieldSet(className: String, fieldName: String, expectedType: String, receivedType: String) :
             Error("invalid set of JVM field $fieldName on class $className. Expected type: $expectedType, received type: $receivedType")
+    }
+
+    object JVMCompat {
+        class InconvertibleType(value: JSValue, type: java.lang.Class<*>) : Error("$value isn't convertible to type $type")
     }
 
     object JVMPackage {

--- a/src/test/kotlin/me/mattco/reeva/test262/JVMValueMapperTests.kt
+++ b/src/test/kotlin/me/mattco/reeva/test262/JVMValueMapperTests.kt
@@ -1,0 +1,289 @@
+package me.mattco.reeva.test262
+
+import me.mattco.reeva.Reeva
+import me.mattco.reeva.runtime.JSValue
+import me.mattco.reeva.runtime.arrays.JSArrayObject
+import me.mattco.reeva.runtime.jvmcompat.JSClassObject
+import me.mattco.reeva.runtime.jvmcompat.JVMValueMapper
+import me.mattco.reeva.runtime.primitives.*
+import me.mattco.reeva.utils.toValue
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import strikt.api.expectThat
+import strikt.api.expectThrows
+import strikt.assertions.*
+import java.lang.reflect.ParameterizedType
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class JVMValueMapperTests {
+    init {
+        Reeva.setup()
+    }
+
+    val realm = Reeva.makeRealm().also { it.initObjects() }
+
+    @AfterAll
+    fun teardown() {
+        Reeva.teardown()
+    }
+
+    @Test
+    fun `JSUndefined maps correctly to JVM types`() {
+        expectThat(JSUndefined.toType<String>())
+            .isA<String>()
+            .isEqualTo("undefined")
+
+        expectThat(JSUndefined.toType<Any>())
+            .isNull()
+
+        expectThat(JSUndefined.toType<Map<*, *>>())
+            .isNull()
+    }
+
+    @Test
+    fun `JSBoolean maps correctly to JVM types`() {
+        expectThat(JSTrue.toType<Boolean>())
+            .isA<Boolean>()
+            .isTrue()
+
+        expectThat(JSFalse.toType<Boolean>())
+            .isA<Boolean>()
+            .isFalse()
+
+        expectThat(JSTrue.toType<Any>())
+            .isA<Boolean>()
+            .isTrue()
+
+        expectThat(JSFalse.toType<Any>())
+            .isA<Boolean>()
+            .isFalse()
+
+        expectThat(JSTrue.toType<String>())
+            .isA<String>()
+            .isEqualTo("true")
+
+        expectThat(JSFalse.toType<String>())
+            .isA<String>()
+            .isEqualTo("false")
+
+        expectThrows<Exception> {
+            JSFalse.toType<Array<*>>()
+        }
+
+        expectThrows<Exception> {
+            JSTrue.toType<Double>()
+        }
+    }
+
+    @Test
+    fun `JSNumber maps correctly to JVM types`() {
+        val underlyingNumber = 5.0
+        val number = JSNumber(underlyingNumber)
+
+        expectThat(number.toType<Double>())
+            .isA<Double>()
+            .isEqualTo(underlyingNumber)
+
+        expectThat(number.toType<Any>())
+            .isA<Double>()
+            .isEqualTo(underlyingNumber)
+
+        // TODO: Need more tests for -inf, +inf, etc.
+        expectThat(number.toType<Float>())
+            .isA<Float>()
+            .isEqualTo(underlyingNumber.toFloat())
+
+        expectThat(number.toType<String>())
+            .isA<String>()
+            .contains("5")
+
+        expectThrows<Exception> {
+            number.toType<Boolean>()
+        }
+    }
+
+    @Nested
+    inner class `JSString maps correctly to JVM types` {
+        val underlyingString = "My string"
+        val jsString = JSString(underlyingString)
+
+        val numberString = "5.1"
+        val jsNumberString = JSString(numberString)
+
+        val singleCharString = "e"
+        val jsCharString = JSString(singleCharString)
+
+        @Test
+        fun `Maps correctly to String & Any`() {
+            expectThat(jsString.toType<String>())
+                .isA<String>()
+                .isEqualTo(underlyingString)
+
+            expectThat(jsString.toType<Any>())
+                .isA<String>()
+                .isEqualTo(underlyingString)
+        }
+
+        @Test
+        fun `Maps correctly to number types`() {
+            expectThat(jsNumberString.toType<Double>())
+                .isA<Double>()
+                .isEqualTo(numberString.toDouble())
+
+            expectThat(jsString.toType<Double>())
+                .isA<Double>()
+                .isEqualTo(Double.NaN)
+        }
+
+        @Test
+        fun `Maps correctly to Char type`() {
+            expectThat(jsCharString.toType<Char>())
+                .isA<Char>()
+                .isEqualTo(singleCharString[0])
+
+            expectThat(jsNumberString.toType<Char>())
+                .isA<Char>()
+                .isEqualTo(numberString.toDouble().toChar())
+
+            expectThrows<Exception> {
+                jsString.toType<Char>()
+            }
+        }
+
+        @Test
+        fun `Fails on invalid types`() {
+            expectThrows<Exception> {
+                jsString.toType<Boolean>()
+            }
+
+            expectThrows<Exception> {
+                jsString.toType<Array<*>>()
+            }
+        }
+    }
+
+    @Test
+    fun `JSNull maps correctly to JVM types`() {
+        expectThat(JSNull.toType<String>())
+            .isNull()
+
+        expectThat(JSNull.toType<Any>())
+            .isNull()
+
+        expectThrows<Exception> {
+            JVMValueMapper.coerceValueToType(JSNull, Double::class.javaPrimitiveType!!)
+        }
+    }
+
+    @Nested
+    inner class `JS JVM values map correctly to JVM types` {
+        val testClass = JSClassObject.create(realm, TestClass::class.java)
+        val testClassInstance = testClass.construct(emptyList(), testClass)
+
+        val numberLikeClass = JSClassObject.create(realm, NumberLikeClass::class.java)
+        val numberLikeInstance = numberLikeClass.construct(emptyList(), numberLikeClass)
+
+        @Test
+        fun `JSClassObject maps correctly to JVM types`() {
+            expectThat(testClass.toType<Class<*>>())
+                .isA<Class<*>>()
+                .isEqualTo(TestClass::class.java)
+
+            expectThat(testClass.toType<Any>())
+                .isA<Class<*>>()
+                .isEqualTo(TestClass::class.java)
+
+            expectThat(testClass.toType<String>())
+                .isA<String>()
+                .isEqualTo(TestClass::class.java.toString())
+
+            expectThrows<Exception> {
+                testClass.toType<TestClass>()
+            }
+
+            expectThrows<Exception> {
+                numberLikeClass.toType<Double>()
+            }
+        }
+
+        @Test
+        fun `JSClassInstanceObject maps correctly to JVM types`() {
+            expectThat(testClassInstance.toType<String>())
+                .isA<String>()
+
+            expectThat(numberLikeInstance.toType<String>())
+                .isA<String>()
+
+            expectThat(testClassInstance.toType<Double>())
+                .isA<Double>()
+                .isEqualTo(Double.NaN)
+
+            expectThat(numberLikeInstance.toType<Double>())
+                .isA<Double>()
+                .isEqualTo(NumberLikeClass().toString().toDouble())
+
+            expectThrows<Exception> {
+                numberLikeInstance.toType<Boolean>()
+            }
+        }
+    }
+
+    @Test
+    fun `JSArrayObject maps correctly to JVM types`() {
+        val array = JSArrayObject.create(realm)
+        array.set(0, 1.0.toValue())
+        array.set(1, 3.0.toValue())
+        array.set(2, "5.0".toValue())
+        val doubleGenericInfo = (TestClass::class.java.declaredMethods.find { it.name == "doubleListConsumer" }!!
+            .genericParameterTypes.first() as ParameterizedType).actualTypeArguments
+        val booleanGenericInfo = (TestClass::class.java.declaredMethods.find { it.name == "booleanListConsumer" }!!
+            .genericParameterTypes.first() as ParameterizedType).actualTypeArguments
+
+        expectThat(array.toType<String>())
+            .isA<String>()
+            .contains("1")
+            .contains("3")
+            .contains("5")
+
+        expectThat(array.toType<Any>())
+            .isA<Array<Any>>()
+
+        expectThat(array.toType<Array<Double>>())
+            .isA<Array<Double>>()
+
+        expectThat(JVMValueMapper.coerceValueToType(array, List::class.java, genericInfo = doubleGenericInfo))
+            .isA<List<Double>>()
+
+        expectThrows<Exception> {
+            JVMValueMapper.coerceValueToType(array, List::class.java, genericInfo = booleanGenericInfo)
+        }
+
+        expectThrows<Exception> {
+            array.toType<Array<Boolean>>()
+        }
+
+        expectThrows<Exception> {
+            array.toType<Double>()
+        }
+    }
+
+    @Test
+    fun `JSObject maps correctly to JVM types`() {
+        // TODO
+    }
+
+    class TestClass {
+        fun doubleListConsumer(list: List<Double>) {}
+        fun booleanListConsumer(list: List<Boolean>) {}
+    }
+
+    class NumberLikeClass {
+        override fun toString(): String {
+            return "5.0"
+        }
+    }
+
+    private inline fun <reified T> JSValue.toType(): Any? = JVMValueMapper.coerceValueToType(this, T::class.java)
+}


### PR DESCRIPTION
This patch implements much better support for js -> jvm argument conversion. It implements a heuristic algorithm to match the best fitting jvm method for any given argument set, based loosely off of the LiveConnect3 specification. Additionally, a new test suite has been added to test the functionality. Currently it only has unit tests for type coercion, and end-to-end tests are still required.

There is still more work to be done in this area, primarily updating the JVM -> JSValue algorithms, as well as converting from more complex types, such as Map or Set, but this is a great start.